### PR TITLE
fix: correct gzip detection and add tests

### DIFF
--- a/msds/mysqldumpsplit.go
+++ b/msds/mysqldumpsplit.go
@@ -26,10 +26,10 @@ type ChannelBus struct {
 }
 
 func isGzip(b *bufio.Reader) bool {
-	if m, err := b.Peek(2); err != nil && m[0] != 0x1f && m[1] != 0x8b {
-		return false
+	if m, err := b.Peek(2); err == nil {
+		return m[0] == 0x1f && m[1] == 0x8b
 	}
-	return true
+	return false
 }
 
 func openReader(f *os.File) *bufio.Reader {

--- a/msds/mysqldumpsplit_test.go
+++ b/msds/mysqldumpsplit_test.go
@@ -3,12 +3,21 @@ package msds
 import (
 	"bufio"
 	"bytes"
+	"compress/gzip"
 	"os"
 	"reflect"
 	"testing"
 )
 
 func Test_isGzip(t *testing.T) {
+	createGzipData := func(data []byte) []byte {
+		var buf bytes.Buffer
+		gz := gzip.NewWriter(&buf)
+		_, _ = gz.Write(data)
+		_ = gz.Close()
+		return buf.Bytes()
+	}
+
 	tests := []struct {
 		name    string
 		content []byte

--- a/msds/mysqldumpsplit_test.go
+++ b/msds/mysqldumpsplit_test.go
@@ -2,25 +2,35 @@ package msds
 
 import (
 	"bufio"
+	"bytes"
 	"os"
 	"reflect"
 	"testing"
 )
 
 func Test_isGzip(t *testing.T) {
-	type args struct {
-		b *bufio.Reader
-	}
 	tests := []struct {
-		name string
-		args args
-		want bool
+		name    string
+		content []byte
+		want    bool
 	}{
-	// TODO: Add test cases.
+		{
+			name:    "gzip file",
+			content: createGzipData([]byte("test data")),
+			want:    true,
+		},
+		{
+			name:    "non-gzip file",
+			content: []byte("test data"),
+			want:    false,
+		},
 	}
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := isGzip(tt.args.b); got != tt.want {
+			b := bytes.NewReader(tt.content)
+			bufReader := bufio.NewReader(b)
+			if got := isGzip(bufReader); got != tt.want {
 				t.Errorf("isGzip() = %v, want %v", got, tt.want)
 			}
 		})

--- a/msds/utils.go
+++ b/msds/utils.go
@@ -1,8 +1,6 @@
 package msds
 
 import (
-	"bytes"
-	"compress/gzip"
 	"errors"
 	"fmt"
 	"math"
@@ -109,12 +107,4 @@ func initLookupTable(rows, columns int) [][]bool {
 		lookup[i] = make([]bool, columns)
 	}
 	return lookup
-}
-
-func createGzipData(data []byte) []byte {
-	var buf bytes.Buffer
-	gz := gzip.NewWriter(&buf)
-	_, _ = gz.Write(data)
-	_ = gz.Close()
-	return buf.Bytes()
 }

--- a/msds/utils.go
+++ b/msds/utils.go
@@ -1,6 +1,8 @@
 package msds
 
 import (
+	"bytes"
+	"compress/gzip"
 	"errors"
 	"fmt"
 	"math"
@@ -107,4 +109,12 @@ func initLookupTable(rows, columns int) [][]bool {
 		lookup[i] = make([]bool, columns)
 	}
 	return lookup
+}
+
+func createGzipData(data []byte) []byte {
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	_, _ = gz.Write(data)
+	_ = gz.Close()
+	return buf.Bytes()
 }


### PR DESCRIPTION
- Updated `isGzip` to accurately detect gzipped files.
- Added test cases for `isGzip` with gzipped and non-gzipped data.
- Introduced `createGzipData` utility for test data generation.

iss: #6